### PR TITLE
Feature/json decoder with user funcs

### DIFF
--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -220,7 +220,7 @@ def object_from_json(
                 num_trials=object_json["num_trials"],
                 infer_noise=object_json["infer_noise"],
             )
-        elif issubclass(_class, SerializationMixin):
+        elif isclass(_class) and issubclass(_class, SerializationMixin):
             return _class(**_class.deserialize_init_args(args=object_json))
 
         return ax_class_from_json_dict(

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import inspect
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, TYPE_CHECKING
 
 from ax.core.arm import Arm
@@ -198,3 +199,7 @@ def botorch_component_from_json(botorch_class: Any, json: Dict[str, Any]) -> Typ
             "by this serialization/deserialization method."
         )
     return botorch_class(**state_dict)
+
+
+def pathlib_from_json(pathsegments):
+    return Path(*pathsegments)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
+from pathlib import Path
 from typing import Any, Dict, Type
 
 from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
@@ -607,3 +608,7 @@ def risk_measure_to_dict(
         "risk_measure": risk_measure.risk_measure,
         "options": risk_measure.options,
     }
+
+
+def pathlib_to_dict(path: Path):
+    return {"__type": path.__class__.__name__, "pathsegments": [str(path)]}

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pathlib
 from typing import Any, Callable, Dict, Type
 
 import torch
@@ -87,7 +88,11 @@ from ax.models.winsorization_config import WinsorizationConfig
 from ax.runners.botorch_test_problem import BotorchTestProblemRunner
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
-from ax.storage.json_store.decoders import class_from_json, transform_type_from_json
+from ax.storage.json_store.decoders import (
+    class_from_json,
+    pathlib_from_json,
+    transform_type_from_json,
+)
 from ax.storage.json_store.encoders import (
     arm_to_dict,
     batch_to_dict,
@@ -117,6 +122,7 @@ from ax.storage.json_store.encoders import (
     outcome_constraint_to_dict,
     parameter_constraint_to_dict,
     parameter_distribution_to_dict,
+    pathlib_to_dict,
     percentile_early_stopping_strategy_to_dict,
     pytorch_cnn_torchvision_benchmark_problem_to_dict,
     range_parameter_to_dict,
@@ -191,6 +197,12 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     OutcomeConstraint: outcome_constraint_to_dict,
     ParameterConstraint: parameter_constraint_to_dict,
     ParameterDistribution: parameter_distribution_to_dict,
+    pathlib.Path: pathlib_to_dict,
+    pathlib.PurePath: pathlib_to_dict,
+    pathlib.PosixPath: pathlib_to_dict,
+    pathlib.WindowsPath: pathlib_to_dict,
+    pathlib.PurePosixPath: pathlib_to_dict,
+    pathlib.PureWindowsPath: pathlib_to_dict,
     PyTorchCNNTorchvisionBenchmarkProblem: pytorch_cnn_torchvision_benchmark_problem_to_dict,  # noqa
     PyTorchCNNMetric: metric_to_dict,
     PyTorchCNNTorchvisionRunner: runner_to_dict,
@@ -291,6 +303,12 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "ParameterConstraintType": ParameterConstraintType,
     "ParameterDistribution": ParameterDistribution,
     "ParameterType": ParameterType,
+    "Path": pathlib_from_json,
+    "PurePath": pathlib_from_json,
+    "PosixPath": pathlib_from_json,
+    "WindowsPath": pathlib_from_json,
+    "PurePosixPath": pathlib_from_json,
+    "PureWindowsPath": pathlib_from_json,
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
     "PyTorchCNNTorchvisionBenchmarkProblem": PyTorchCNNTorchvisionBenchmarkProblem,
     "PyTorchCNNMetric": PyTorchCNNMetric,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -92,6 +92,7 @@ from ax.utils.testing.core_stubs import (
     get_outcome_constraint,
     get_parameter_constraint,
     get_parameter_distribution,
+    get_pathlib_path,
     get_percentile_early_stopping_strategy,
     get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     get_percentile_early_stopping_strategy_with_true_objective_metric_name,
@@ -169,6 +170,7 @@ TEST_CASES = [
     ("OrEarlyStoppingStrategy", get_or_early_stopping_strategy),
     ("OrderConstraint", get_order_constraint),
     ("OutcomeConstraint", get_outcome_constraint),
+    ("Path", get_pathlib_path),
     ("PercentileEarlyStoppingStrategy", get_percentile_early_stopping_strategy),
     (
         "PercentileEarlyStoppingStrategy",

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from logging import Logger
+from pathlib import Path
 from typing import (
     Any,
     cast,
@@ -1976,3 +1977,7 @@ def get_parameter_distribution() -> ParameterDistribution:
         distribution_class="norm",
         distribution_parameters={"loc": 1.0, "scale": 0.5},
     )
+
+
+def get_pathlib_path() -> Path:
+    return Path("some/meaningless/path")


### PR DESCRIPTION
- [Add check for isclass in object_from_json](https://github.com/madeline-scyphers/Ax/commit/be52d057e19560df9051c1daf22a71c6745b95c8)
  Make all checks for `issubclass` in `object_from_json`
  first check if `isclass` so that if it isn't a class
  it won't error.
  This should allow functions to be registered in the decoder